### PR TITLE
Fix macOS sim: CANcoder crash, Xbox controller input, CI

### DIFF
--- a/.github/workflows/robot_ci.yml
+++ b/.github/workflows/robot_ci.yml
@@ -117,7 +117,7 @@ jobs:
   BuildDocs:
     name: Build Documentation
     runs-on: ubuntu-latest
-    needs: [RobotUnitTestWindows, StaticCritical]
+    needs: [RobotUnitTestWindows, RobotUnitTestMacOS, StaticCritical]
     steps:
     - uses: actions/checkout@v4
 

--- a/examples/controller_test/physics.py
+++ b/examples/controller_test/physics.py
@@ -1,139 +1,20 @@
 """
 Minimal physics engine that only runs the SDL2 controller bridge on macOS.
+No robot simulation — just controller input forwarding for testing.
+
+See utils/sim/sdl2_controller_bridge.py for full documentation.
 """
 
 import sys
-import time
+sys.path.insert(0, "../..")  # Allow importing from project root
 
-import hal.simulation
-import wpilib
 from pyfrc.physics.core import PhysicsInterface
-
-_sdl2 = None
-_gc = None
-_port = 0
-_AXIS_MAP = {}
-_BUTTON_MAP = {}
-_DPAD = []
-
-
-def _dpad_to_pov(up, down, left, right):
-    if up and right:
-        return 45
-    if right and down:
-        return 135
-    if down and left:
-        return 225
-    if left and up:
-        return 315
-    if up:
-        return 0
-    if right:
-        return 90
-    if down:
-        return 180
-    if left:
-        return 270
-    return -1
+from utils.sim.sdl2_controller_bridge import start_controller_bridge
 
 
 class PhysicsEngine:
     def __init__(self, physics_controller: PhysicsInterface, robot) -> None:
-        global _sdl2, _gc, _AXIS_MAP, _BUTTON_MAP, _DPAD
-
-        self._sdl2_ok = False
-        if sys.platform != "darwin":
-            return
-
-        try:
-            import sdl2
-            _sdl2 = sdl2
-        except ImportError:
-            wpilib.reportWarning(
-                "pysdl2 not installed — 'pip install pysdl2 pysdl2-dll'"
-            )
-            return
-
-        _AXIS_MAP = {
-            sdl2.SDL_CONTROLLER_AXIS_LEFTX: 0,
-            sdl2.SDL_CONTROLLER_AXIS_LEFTY: 1,
-            sdl2.SDL_CONTROLLER_AXIS_TRIGGERLEFT: 2,
-            sdl2.SDL_CONTROLLER_AXIS_TRIGGERRIGHT: 3,
-            sdl2.SDL_CONTROLLER_AXIS_RIGHTX: 4,
-            sdl2.SDL_CONTROLLER_AXIS_RIGHTY: 5,
-        }
-        _BUTTON_MAP = {
-            sdl2.SDL_CONTROLLER_BUTTON_A: 0,
-            sdl2.SDL_CONTROLLER_BUTTON_B: 1,
-            sdl2.SDL_CONTROLLER_BUTTON_X: 2,
-            sdl2.SDL_CONTROLLER_BUTTON_Y: 3,
-            sdl2.SDL_CONTROLLER_BUTTON_LEFTSHOULDER: 4,
-            sdl2.SDL_CONTROLLER_BUTTON_RIGHTSHOULDER: 5,
-            sdl2.SDL_CONTROLLER_BUTTON_BACK: 6,
-            sdl2.SDL_CONTROLLER_BUTTON_START: 7,
-            sdl2.SDL_CONTROLLER_BUTTON_LEFTSTICK: 8,
-            sdl2.SDL_CONTROLLER_BUTTON_RIGHTSTICK: 9,
-        }
-        _DPAD = [
-            sdl2.SDL_CONTROLLER_BUTTON_DPAD_UP,
-            sdl2.SDL_CONTROLLER_BUTTON_DPAD_DOWN,
-            sdl2.SDL_CONTROLLER_BUTTON_DPAD_LEFT,
-            sdl2.SDL_CONTROLLER_BUTTON_DPAD_RIGHT,
-        ]
-
-        sdl2.SDL_SetHint(sdl2.SDL_HINT_JOYSTICK_MFI, b"1")
-        sdl2.SDL_Init(sdl2.SDL_INIT_GAMECONTROLLER)
-
-        for _ in range(20):
-            sdl2.SDL_PumpEvents()
-            time.sleep(0.05)
-
-        for idx in range(sdl2.SDL_NumJoysticks()):
-            if sdl2.SDL_IsGameController(idx):
-                _gc = sdl2.SDL_GameControllerOpen(idx)
-                break
-
-        if not _gc:
-            print("SDL2 bridge: no game controllers found")
-            return
-
-        gc_name = sdl2.SDL_GameControllerName(_gc)
-        if gc_name and isinstance(gc_name, bytes):
-            gc_name = gc_name.decode()
-        wpilib.reportWarning(f"SDL2 bridge: '{gc_name}' → port {_port}")
-        self._sdl2_ok = True
-        self._tick = 0
+        start_controller_bridge()
 
     def update_sim(self, now: float, tm_diff: float) -> None:
-        if not self._sdl2_ok:
-            return
-
-        _sdl2.SDL_PumpEvents()
-
-        hal.simulation.setJoystickAxisCount(_port, 6)
-        hal.simulation.setJoystickButtonCount(_port, 10)
-        hal.simulation.setJoystickPOVCount(_port, 1)
-
-        for sdl_axis, wpi_axis in _AXIS_MAP.items():
-            raw = _sdl2.SDL_GameControllerGetAxis(_gc, sdl_axis)
-            hal.simulation.setJoystickAxis(_port, wpi_axis, raw / 32767.0)
-
-        buttons = 0
-        for sdl_btn, bit_index in _BUTTON_MAP.items():
-            if _sdl2.SDL_GameControllerGetButton(_gc, sdl_btn):
-                buttons |= (1 << bit_index)
-        hal.simulation.setJoystickButtonsValue(_port, buttons)
-
-        dpad = [
-            bool(_sdl2.SDL_GameControllerGetButton(_gc, b))
-            for b in _DPAD
-        ]
-        hal.simulation.setJoystickPOV(_port, 0, _dpad_to_pov(*dpad))
-
-        hal.simulation.notifyDriverStationNewData()
-
-        self._tick += 1
-        if self._tick % 100 == 0:
-            lx = _sdl2.SDL_GameControllerGetAxis(_gc, _sdl2.SDL_CONTROLLER_AXIS_LEFTX) / 32767.0
-            ly = _sdl2.SDL_GameControllerGetAxis(_gc, _sdl2.SDL_CONTROLLER_AXIS_LEFTY) / 32767.0
-            print(f"SDL2 bridge tick {self._tick}: LX={lx:+.2f} LY={ly:+.2f} buttons=0x{buttons:04x}")
+        pass

--- a/examples/controller_test/physics.py
+++ b/examples/controller_test/physics.py
@@ -1,0 +1,139 @@
+"""
+Minimal physics engine that only runs the SDL2 controller bridge on macOS.
+"""
+
+import sys
+import time
+
+import hal.simulation
+import wpilib
+from pyfrc.physics.core import PhysicsInterface
+
+_sdl2 = None
+_gc = None
+_port = 0
+_AXIS_MAP = {}
+_BUTTON_MAP = {}
+_DPAD = []
+
+
+def _dpad_to_pov(up, down, left, right):
+    if up and right:
+        return 45
+    if right and down:
+        return 135
+    if down and left:
+        return 225
+    if left and up:
+        return 315
+    if up:
+        return 0
+    if right:
+        return 90
+    if down:
+        return 180
+    if left:
+        return 270
+    return -1
+
+
+class PhysicsEngine:
+    def __init__(self, physics_controller: PhysicsInterface, robot) -> None:
+        global _sdl2, _gc, _AXIS_MAP, _BUTTON_MAP, _DPAD
+
+        self._sdl2_ok = False
+        if sys.platform != "darwin":
+            return
+
+        try:
+            import sdl2
+            _sdl2 = sdl2
+        except ImportError:
+            wpilib.reportWarning(
+                "pysdl2 not installed — 'pip install pysdl2 pysdl2-dll'"
+            )
+            return
+
+        _AXIS_MAP = {
+            sdl2.SDL_CONTROLLER_AXIS_LEFTX: 0,
+            sdl2.SDL_CONTROLLER_AXIS_LEFTY: 1,
+            sdl2.SDL_CONTROLLER_AXIS_TRIGGERLEFT: 2,
+            sdl2.SDL_CONTROLLER_AXIS_TRIGGERRIGHT: 3,
+            sdl2.SDL_CONTROLLER_AXIS_RIGHTX: 4,
+            sdl2.SDL_CONTROLLER_AXIS_RIGHTY: 5,
+        }
+        _BUTTON_MAP = {
+            sdl2.SDL_CONTROLLER_BUTTON_A: 0,
+            sdl2.SDL_CONTROLLER_BUTTON_B: 1,
+            sdl2.SDL_CONTROLLER_BUTTON_X: 2,
+            sdl2.SDL_CONTROLLER_BUTTON_Y: 3,
+            sdl2.SDL_CONTROLLER_BUTTON_LEFTSHOULDER: 4,
+            sdl2.SDL_CONTROLLER_BUTTON_RIGHTSHOULDER: 5,
+            sdl2.SDL_CONTROLLER_BUTTON_BACK: 6,
+            sdl2.SDL_CONTROLLER_BUTTON_START: 7,
+            sdl2.SDL_CONTROLLER_BUTTON_LEFTSTICK: 8,
+            sdl2.SDL_CONTROLLER_BUTTON_RIGHTSTICK: 9,
+        }
+        _DPAD = [
+            sdl2.SDL_CONTROLLER_BUTTON_DPAD_UP,
+            sdl2.SDL_CONTROLLER_BUTTON_DPAD_DOWN,
+            sdl2.SDL_CONTROLLER_BUTTON_DPAD_LEFT,
+            sdl2.SDL_CONTROLLER_BUTTON_DPAD_RIGHT,
+        ]
+
+        sdl2.SDL_SetHint(sdl2.SDL_HINT_JOYSTICK_MFI, b"1")
+        sdl2.SDL_Init(sdl2.SDL_INIT_GAMECONTROLLER)
+
+        for _ in range(20):
+            sdl2.SDL_PumpEvents()
+            time.sleep(0.05)
+
+        for idx in range(sdl2.SDL_NumJoysticks()):
+            if sdl2.SDL_IsGameController(idx):
+                _gc = sdl2.SDL_GameControllerOpen(idx)
+                break
+
+        if not _gc:
+            print("SDL2 bridge: no game controllers found")
+            return
+
+        gc_name = sdl2.SDL_GameControllerName(_gc)
+        if gc_name and isinstance(gc_name, bytes):
+            gc_name = gc_name.decode()
+        wpilib.reportWarning(f"SDL2 bridge: '{gc_name}' → port {_port}")
+        self._sdl2_ok = True
+        self._tick = 0
+
+    def update_sim(self, now: float, tm_diff: float) -> None:
+        if not self._sdl2_ok:
+            return
+
+        _sdl2.SDL_PumpEvents()
+
+        hal.simulation.setJoystickAxisCount(_port, 6)
+        hal.simulation.setJoystickButtonCount(_port, 10)
+        hal.simulation.setJoystickPOVCount(_port, 1)
+
+        for sdl_axis, wpi_axis in _AXIS_MAP.items():
+            raw = _sdl2.SDL_GameControllerGetAxis(_gc, sdl_axis)
+            hal.simulation.setJoystickAxis(_port, wpi_axis, raw / 32767.0)
+
+        buttons = 0
+        for sdl_btn, bit_index in _BUTTON_MAP.items():
+            if _sdl2.SDL_GameControllerGetButton(_gc, sdl_btn):
+                buttons |= (1 << bit_index)
+        hal.simulation.setJoystickButtonsValue(_port, buttons)
+
+        dpad = [
+            bool(_sdl2.SDL_GameControllerGetButton(_gc, b))
+            for b in _DPAD
+        ]
+        hal.simulation.setJoystickPOV(_port, 0, _dpad_to_pov(*dpad))
+
+        hal.simulation.notifyDriverStationNewData()
+
+        self._tick += 1
+        if self._tick % 100 == 0:
+            lx = _sdl2.SDL_GameControllerGetAxis(_gc, _sdl2.SDL_CONTROLLER_AXIS_LEFTX) / 32767.0
+            ly = _sdl2.SDL_GameControllerGetAxis(_gc, _sdl2.SDL_CONTROLLER_AXIS_LEFTY) / 32767.0
+            print(f"SDL2 bridge tick {self._tick}: LX={lx:+.2f} LY={ly:+.2f} buttons=0x{buttons:04x}")

--- a/examples/controller_test/robot.py
+++ b/examples/controller_test/robot.py
@@ -1,0 +1,40 @@
+"""
+Minimal test robot to verify Xbox controller inputs are received on Mac sim.
+Prints axis and button values to console every 500ms.
+"""
+
+import wpilib
+
+
+class ControllerTestRobot(wpilib.TimedRobot):
+    def robotInit(self):
+        self.controller = wpilib.XboxController(0)
+        self.timer = wpilib.Timer()
+        self.timer.start()
+
+    def teleopPeriodic(self):
+        if self.timer.advanceIfElapsed(0.5):
+            lx = self.controller.getLeftX()
+            ly = self.controller.getLeftY()
+            rx = self.controller.getRightX()
+            ry = self.controller.getRightY()
+            lt = self.controller.getLeftTriggerAxis()
+            rt = self.controller.getRightTriggerAxis()
+            a = self.controller.getAButton()
+            b = self.controller.getBButton()
+            x = self.controller.getXButton()
+            y = self.controller.getYButton()
+            lb = self.controller.getLeftBumper()
+            rb = self.controller.getRightBumper()
+            pov = self.controller.getPOV()
+
+            print(
+                f"Axes: LX={lx:+.2f} LY={ly:+.2f} RX={rx:+.2f} RY={ry:+.2f} "
+                f"LT={lt:.2f} RT={rt:.2f} | "
+                f"Buttons: A={a} B={b} X={x} Y={y} LB={lb} RB={rb} | "
+                f"POV={pov}"
+            )
+
+
+if __name__ == "__main__":
+    wpilib.run(ControllerTestRobot)

--- a/physics.py
+++ b/physics.py
@@ -45,21 +45,22 @@ logger = logging.getLogger("physics")
 # macOS SDL2 controller bridge
 # ---------------------------------------------------------------------------
 
-def _start_sdl2_controller_bridge(port: int) -> None:
-    """Spawn a daemon thread that reads one game controller via SDL2 and
-    feeds its state into ``GenericHIDSim`` for the given WPILib joystick
-    *port*.
+def _start_sdl2_controller_bridge() -> None:
+    """Spawn a daemon thread that discovers game controllers via SDL2 and
+    feeds their state into the HAL sim.
 
-    Called only when macOS is detected and the port has a mapped controller
-    with 0 reported axes (GLFW bug).
+    The first controller found maps to WPILib joystick port 0 (driver),
+    the second to port 1 (operator).  If no controllers are detected the
+    thread exits silently and the sim GUI's virtual joystick still works.
     """
     try:
         import sdl2
     except ImportError:
-        logger.warning(
+        msg = (
             "pysdl2 not installed — Xbox controller input in sim requires "
             "'pip install pysdl2 pysdl2-dll' on macOS"
         )
+        wpilib.reportWarning(msg)
         return
 
     # --- mapping tables: SDL2 game controller → WPILib XboxController ---
@@ -71,17 +72,19 @@ def _start_sdl2_controller_bridge(port: int) -> None:
         sdl2.SDL_CONTROLLER_AXIS_RIGHTX: 4,
         sdl2.SDL_CONTROLLER_AXIS_RIGHTY: 5,
     }
+    # SDL2 button → bit index for HAL button bitmask.
+    # WPILib buttons are 1-based; bit 0 = button 1 (A), bit 1 = button 2 (B), etc.
     _BUTTON_MAP = {
-        sdl2.SDL_CONTROLLER_BUTTON_A: 1,
-        sdl2.SDL_CONTROLLER_BUTTON_B: 2,
-        sdl2.SDL_CONTROLLER_BUTTON_X: 3,
-        sdl2.SDL_CONTROLLER_BUTTON_Y: 4,
-        sdl2.SDL_CONTROLLER_BUTTON_LEFTSHOULDER: 5,
-        sdl2.SDL_CONTROLLER_BUTTON_RIGHTSHOULDER: 6,
-        sdl2.SDL_CONTROLLER_BUTTON_BACK: 7,
-        sdl2.SDL_CONTROLLER_BUTTON_START: 8,
-        sdl2.SDL_CONTROLLER_BUTTON_LEFTSTICK: 9,
-        sdl2.SDL_CONTROLLER_BUTTON_RIGHTSTICK: 10,
+        sdl2.SDL_CONTROLLER_BUTTON_A: 0,
+        sdl2.SDL_CONTROLLER_BUTTON_B: 1,
+        sdl2.SDL_CONTROLLER_BUTTON_X: 2,
+        sdl2.SDL_CONTROLLER_BUTTON_Y: 3,
+        sdl2.SDL_CONTROLLER_BUTTON_LEFTSHOULDER: 4,
+        sdl2.SDL_CONTROLLER_BUTTON_RIGHTSHOULDER: 5,
+        sdl2.SDL_CONTROLLER_BUTTON_BACK: 6,
+        sdl2.SDL_CONTROLLER_BUTTON_START: 7,
+        sdl2.SDL_CONTROLLER_BUTTON_LEFTSTICK: 8,
+        sdl2.SDL_CONTROLLER_BUTTON_RIGHTSTICK: 9,
     }
     _DPAD = [
         sdl2.SDL_CONTROLLER_BUTTON_DPAD_UP,
@@ -118,46 +121,58 @@ def _start_sdl2_controller_bridge(port: int) -> None:
             sdl2.SDL_PumpEvents()
             time.sleep(0.05)
 
-        # Find the first game-controller-capable device
-        gc = None
+        # Open all game-controller-capable devices, map to WPILib ports.
+        # First controller → port 0 (driver), second → port 1 (operator).
+        controllers = []  # list of (sdl2_gc, port)
         for idx in range(sdl2.SDL_NumJoysticks()):
-            if sdl2.SDL_IsGameController(idx):
-                gc = sdl2.SDL_GameControllerOpen(idx)
-                break
+            if not sdl2.SDL_IsGameController(idx):
+                continue
+            gc = sdl2.SDL_GameControllerOpen(idx)
+            if not gc:
+                continue
+            port = len(controllers)
+            gc_name = sdl2.SDL_GameControllerName(gc)
+            if gc_name and isinstance(gc_name, bytes):
+                gc_name = gc_name.decode()
+            wpilib.reportWarning(
+                f"SDL2 bridge: '{gc_name}' → HAL joystick port {port}. "
+                f"Do NOT assign this controller in the sim GUI System Joystick panel."
+            )
+            hal.simulation.setJoystickAxisCount(port, 6)
+            hal.simulation.setJoystickButtonCount(port, 10)
+            hal.simulation.setJoystickPOVCount(port, 1)
+            hal.simulation.setJoystickIsXbox(port, True)
+            hal.simulation.setJoystickName(port, gc_name or "SDL2 Controller")
+            controllers.append((gc, port))
 
-        if not gc:
-            logger.info("SDL2 bridge: no game controllers found")
+        if not controllers:
+            # No physical controllers — exit silently so the sim GUI's
+            # virtual joystick panel still works.
             sdl2.SDL_Quit()
             return
 
-        gc_name = sdl2.SDL_GameControllerName(gc)
-        if gc_name and isinstance(gc_name, bytes):
-            gc_name = gc_name.decode()
-        logger.warning("SDL2 bridge: '%s' → HAL joystick port %d", gc_name, port)
-
-        sim = wpilib.simulation.GenericHIDSim(port)
-        sim.setAxisCount(6)
-        sim.setButtonCount(10)
-        sim.setPOVCount(1)
-
+        # Poll loop — ~100 Hz to keep input responsive
         while True:
             sdl2.SDL_PumpEvents()
 
-            for sdl_axis, wpi_axis in _AXIS_MAP.items():
-                raw = sdl2.SDL_GameControllerGetAxis(gc, sdl_axis)
-                sim.setRawAxis(wpi_axis, raw / 32767.0)
+            for gc, port in controllers:
+                for sdl_axis, wpi_axis in _AXIS_MAP.items():
+                    raw = sdl2.SDL_GameControllerGetAxis(gc, sdl_axis)
+                    hal.simulation.setJoystickAxis(port, wpi_axis, raw / 32767.0)
 
-            for sdl_btn, wpi_btn in _BUTTON_MAP.items():
-                sim.setRawButton(
-                    wpi_btn,
-                    bool(sdl2.SDL_GameControllerGetButton(gc, sdl_btn)),
-                )
+                buttons = 0
+                for sdl_btn, bit_index in _BUTTON_MAP.items():
+                    if sdl2.SDL_GameControllerGetButton(gc, sdl_btn):
+                        buttons |= (1 << bit_index)
+                hal.simulation.setJoystickButtonsValue(port, buttons)
 
-            dpad = [
-                bool(sdl2.SDL_GameControllerGetButton(gc, b)) for b in _DPAD
-            ]
-            sim.setPOV(0, _dpad_to_pov(*dpad))
+                dpad = [
+                    bool(sdl2.SDL_GameControllerGetButton(gc, b))
+                    for b in _DPAD
+                ]
+                hal.simulation.setJoystickPOV(port, 0, _dpad_to_pov(*dpad))
 
+            hal.simulation.notifyDriverStationNewData()
             time.sleep(0.01)
 
     t = threading.Thread(
@@ -247,37 +262,11 @@ class PhysicsEngine:
             # ignore errors here and leave _navx_yaw as None.
             pass
 
-        # macOS controller bridge state — checked each tick until resolved.
-        # We monitor joystick ports 0 and 1 (driver and operator).  Once a
-        # port is assigned in the sim GUI but reports 0 axes we know GLFW
-        # cannot read it and start the SDL2 bridge for that port.
+        # On macOS, GLFW cannot read Xbox/PlayStation controllers at all
+        # (reports 0 axes, 0 buttons).  Start the SDL2 bridge immediately
+        # for the driver controller port.
         if sys.platform == "darwin":
-            self._controller_bridge_ports_to_check: set[int] = {0, 1}
-        else:
-            self._controller_bridge_ports_to_check: set[int] = set()
-
-    def _check_controller_bridge(self) -> None:
-        """On macOS, detect joystick ports that are mapped but broken (0 axes)
-        and start the SDL2 bridge for them.  Removes ports from the check set
-        once resolved (either working or bridged)."""
-        resolved = set()
-        for port in self._controller_bridge_ports_to_check:
-            axis_count, button_count, _ = hal.simulation.getJoystickCounts(port)
-            if axis_count > 0:
-                # GLFW is reading this port fine — no bridge needed
-                resolved.add(port)
-            elif button_count > 0:
-                # Controller is mapped (has buttons) but reports 0 axes —
-                # this is the broken GLFW state on macOS.
-                logger.warning(
-                    "macOS GLFW reports 0 axes for joystick port %d "
-                    "(buttons=%d) — starting SDL2 bridge",
-                    port, button_count,
-                )
-                _start_sdl2_controller_bridge(port)
-                resolved.add(port)
-            # else: nothing mapped yet, keep checking
-        self._controller_bridge_ports_to_check -= resolved
+            _start_sdl2_controller_bridge()
 
     def update_sim(self, now: float, tm_diff: float) -> None:
         """
@@ -295,10 +284,6 @@ class PhysicsEngine:
             now: current timestamp in seconds
             tm_diff: elapsed time since last call in seconds
         """
-        # Check for broken macOS controller input each tick until resolved.
-        if self._controller_bridge_ports_to_check:
-            self._check_controller_bridge()
-
         module_states = []
 
         for module, drive_sim, steer_sim in zip(

--- a/physics.py
+++ b/physics.py
@@ -154,6 +154,8 @@ class PhysicsEngine:
             )
 
         # Integrate chassis speeds into robot pose.
+        if len(module_states) != 4:
+            return
         speeds = self.kinematics.toChassisSpeeds(tuple(module_states))
         self._pose = self._pose.exp(
             Twist2d(

--- a/physics.py
+++ b/physics.py
@@ -10,21 +10,25 @@ Robot field pose is integrated from swerve kinematics and fed back to:
   - The Field2d widget (visible in the sim GUI)
   - The NavX gyro sim device (so heading-based field-relative drive works)
 
-On macOS the WPILib sim GUI (GLFW) cannot read Xbox/PlayStation controller
-inputs because Apple's Game Controller framework intercepts them.  An optional
-SDL2-based bridge detects this at runtime — when a joystick port is mapped in
-the sim GUI but reports 0 axes, the bridge takes over and feeds controller
-data into the HAL sim.  Install ``pysdl2`` and ``pysdl2-dll`` to enable
-(not needed on Windows/Linux).
+macOS notes
+-----------
+Two platform-specific workarounds are applied during simulation on Mac:
+
+1. **CANcoder sim frames unavailable at init** — CTRE phoenix6's sim backend
+   on macOS does not deliver CAN frames in time for module initialization.
+   ``baseline_relative_encoders()`` in ``swerve_module.py`` handles this by
+   defaulting the steer baseline to 0° instead of raising.  The physics engine
+   also guards against an empty module list (``len(module_states) != 4``).
+
+2. **Xbox/PlayStation controller input** — Apple's Game Controller framework
+   intercepts these devices, making them invisible to GLFW (the input backend
+   used by the WPILib sim GUI).  An SDL2-based bridge
+   (``utils/sim/sdl2_controller_bridge``) reads controllers via SDL2 and writes
+   their state to the HAL sim.  See that module's docstring for setup details.
 """
 
-import logging
-import sys
-import threading
-import time
 import typing
 
-import hal.simulation
 import ntcore
 import rev
 import wpilib
@@ -35,150 +39,10 @@ from wpimath.geometry import Pose2d, Rotation2d, Twist2d
 from wpimath.kinematics import SwerveModuleState
 from wpimath.system.plant import DCMotor
 
+from utils.sim.sdl2_controller_bridge import start_controller_bridge
+
 if typing.TYPE_CHECKING:
     from robot import MyRobot
-
-logger = logging.getLogger("physics")
-
-
-# ---------------------------------------------------------------------------
-# macOS SDL2 controller bridge
-# ---------------------------------------------------------------------------
-
-def _start_sdl2_controller_bridge() -> None:
-    """Spawn a daemon thread that discovers game controllers via SDL2 and
-    feeds their state into the HAL sim.
-
-    The first controller found maps to WPILib joystick port 0 (driver),
-    the second to port 1 (operator).  If no controllers are detected the
-    thread exits silently and the sim GUI's virtual joystick still works.
-    """
-    try:
-        import sdl2
-    except ImportError:
-        msg = (
-            "pysdl2 not installed — Xbox controller input in sim requires "
-            "'pip install pysdl2 pysdl2-dll' on macOS"
-        )
-        wpilib.reportWarning(msg)
-        return
-
-    # --- mapping tables: SDL2 game controller → WPILib XboxController ---
-    _AXIS_MAP = {
-        sdl2.SDL_CONTROLLER_AXIS_LEFTX: 0,
-        sdl2.SDL_CONTROLLER_AXIS_LEFTY: 1,
-        sdl2.SDL_CONTROLLER_AXIS_TRIGGERLEFT: 2,
-        sdl2.SDL_CONTROLLER_AXIS_TRIGGERRIGHT: 3,
-        sdl2.SDL_CONTROLLER_AXIS_RIGHTX: 4,
-        sdl2.SDL_CONTROLLER_AXIS_RIGHTY: 5,
-    }
-    # SDL2 button → bit index for HAL button bitmask.
-    # WPILib buttons are 1-based; bit 0 = button 1 (A), bit 1 = button 2 (B), etc.
-    _BUTTON_MAP = {
-        sdl2.SDL_CONTROLLER_BUTTON_A: 0,
-        sdl2.SDL_CONTROLLER_BUTTON_B: 1,
-        sdl2.SDL_CONTROLLER_BUTTON_X: 2,
-        sdl2.SDL_CONTROLLER_BUTTON_Y: 3,
-        sdl2.SDL_CONTROLLER_BUTTON_LEFTSHOULDER: 4,
-        sdl2.SDL_CONTROLLER_BUTTON_RIGHTSHOULDER: 5,
-        sdl2.SDL_CONTROLLER_BUTTON_BACK: 6,
-        sdl2.SDL_CONTROLLER_BUTTON_START: 7,
-        sdl2.SDL_CONTROLLER_BUTTON_LEFTSTICK: 8,
-        sdl2.SDL_CONTROLLER_BUTTON_RIGHTSTICK: 9,
-    }
-    _DPAD = [
-        sdl2.SDL_CONTROLLER_BUTTON_DPAD_UP,
-        sdl2.SDL_CONTROLLER_BUTTON_DPAD_DOWN,
-        sdl2.SDL_CONTROLLER_BUTTON_DPAD_LEFT,
-        sdl2.SDL_CONTROLLER_BUTTON_DPAD_RIGHT,
-    ]
-
-    def _dpad_to_pov(up, down, left, right):
-        if up and right:
-            return 45
-        if right and down:
-            return 135
-        if down and left:
-            return 225
-        if left and up:
-            return 315
-        if up:
-            return 0
-        if right:
-            return 90
-        if down:
-            return 180
-        if left:
-            return 270
-        return -1
-
-    def _bridge_thread():
-        sdl2.SDL_SetHint(sdl2.SDL_HINT_JOYSTICK_MFI, b"1")
-        sdl2.SDL_Init(sdl2.SDL_INIT_GAMECONTROLLER)
-
-        # Allow time for controller discovery
-        for _ in range(20):
-            sdl2.SDL_PumpEvents()
-            time.sleep(0.05)
-
-        # Open all game-controller-capable devices, map to WPILib ports.
-        # First controller → port 0 (driver), second → port 1 (operator).
-        controllers = []  # list of (sdl2_gc, port)
-        for idx in range(sdl2.SDL_NumJoysticks()):
-            if not sdl2.SDL_IsGameController(idx):
-                continue
-            gc = sdl2.SDL_GameControllerOpen(idx)
-            if not gc:
-                continue
-            port = len(controllers)
-            gc_name = sdl2.SDL_GameControllerName(gc)
-            if gc_name and isinstance(gc_name, bytes):
-                gc_name = gc_name.decode()
-            wpilib.reportWarning(
-                f"SDL2 bridge: '{gc_name}' → HAL joystick port {port}. "
-                f"Do NOT assign this controller in the sim GUI System Joystick panel."
-            )
-            hal.simulation.setJoystickAxisCount(port, 6)
-            hal.simulation.setJoystickButtonCount(port, 10)
-            hal.simulation.setJoystickPOVCount(port, 1)
-            hal.simulation.setJoystickIsXbox(port, True)
-            hal.simulation.setJoystickName(port, gc_name or "SDL2 Controller")
-            controllers.append((gc, port))
-
-        if not controllers:
-            # No physical controllers — exit silently so the sim GUI's
-            # virtual joystick panel still works.
-            sdl2.SDL_Quit()
-            return
-
-        # Poll loop — ~100 Hz to keep input responsive
-        while True:
-            sdl2.SDL_PumpEvents()
-
-            for gc, port in controllers:
-                for sdl_axis, wpi_axis in _AXIS_MAP.items():
-                    raw = sdl2.SDL_GameControllerGetAxis(gc, sdl_axis)
-                    hal.simulation.setJoystickAxis(port, wpi_axis, raw / 32767.0)
-
-                buttons = 0
-                for sdl_btn, bit_index in _BUTTON_MAP.items():
-                    if sdl2.SDL_GameControllerGetButton(gc, sdl_btn):
-                        buttons |= (1 << bit_index)
-                hal.simulation.setJoystickButtonsValue(port, buttons)
-
-                dpad = [
-                    bool(sdl2.SDL_GameControllerGetButton(gc, b))
-                    for b in _DPAD
-                ]
-                hal.simulation.setJoystickPOV(port, 0, _dpad_to_pov(*dpad))
-
-            hal.simulation.notifyDriverStationNewData()
-            time.sleep(0.01)
-
-    t = threading.Thread(
-        target=_bridge_thread, daemon=True, name="sdl2-controller-bridge"
-    )
-    t.start()
 
 
 class PhysicsEngine:
@@ -262,11 +126,8 @@ class PhysicsEngine:
             # ignore errors here and leave _navx_yaw as None.
             pass
 
-        # On macOS, GLFW cannot read Xbox/PlayStation controllers at all
-        # (reports 0 axes, 0 buttons).  Start the SDL2 bridge immediately
-        # for the driver controller port.
-        if sys.platform == "darwin":
-            _start_sdl2_controller_bridge()
+        # On macOS, start the SDL2 controller bridge (see module docstring).
+        start_controller_bridge()
 
     def update_sim(self, now: float, tm_diff: float) -> None:
         """

--- a/physics.py
+++ b/physics.py
@@ -9,10 +9,22 @@ visualization all respond correctly in simulation without tuning a dynamic model
 Robot field pose is integrated from swerve kinematics and fed back to:
   - The Field2d widget (visible in the sim GUI)
   - The NavX gyro sim device (so heading-based field-relative drive works)
+
+On macOS the WPILib sim GUI (GLFW) cannot read Xbox/PlayStation controller
+inputs because Apple's Game Controller framework intercepts them.  An optional
+SDL2-based bridge detects this at runtime — when a joystick port is mapped in
+the sim GUI but reports 0 axes, the bridge takes over and feeds controller
+data into the HAL sim.  Install ``pysdl2`` and ``pysdl2-dll`` to enable
+(not needed on Windows/Linux).
 """
 
+import logging
+import sys
+import threading
+import time
 import typing
 
+import hal.simulation
 import ntcore
 import rev
 import wpilib
@@ -25,6 +37,133 @@ from wpimath.system.plant import DCMotor
 
 if typing.TYPE_CHECKING:
     from robot import MyRobot
+
+logger = logging.getLogger("physics")
+
+
+# ---------------------------------------------------------------------------
+# macOS SDL2 controller bridge
+# ---------------------------------------------------------------------------
+
+def _start_sdl2_controller_bridge(port: int) -> None:
+    """Spawn a daemon thread that reads one game controller via SDL2 and
+    feeds its state into ``GenericHIDSim`` for the given WPILib joystick
+    *port*.
+
+    Called only when macOS is detected and the port has a mapped controller
+    with 0 reported axes (GLFW bug).
+    """
+    try:
+        import sdl2
+    except ImportError:
+        logger.warning(
+            "pysdl2 not installed — Xbox controller input in sim requires "
+            "'pip install pysdl2 pysdl2-dll' on macOS"
+        )
+        return
+
+    # --- mapping tables: SDL2 game controller → WPILib XboxController ---
+    _AXIS_MAP = {
+        sdl2.SDL_CONTROLLER_AXIS_LEFTX: 0,
+        sdl2.SDL_CONTROLLER_AXIS_LEFTY: 1,
+        sdl2.SDL_CONTROLLER_AXIS_TRIGGERLEFT: 2,
+        sdl2.SDL_CONTROLLER_AXIS_TRIGGERRIGHT: 3,
+        sdl2.SDL_CONTROLLER_AXIS_RIGHTX: 4,
+        sdl2.SDL_CONTROLLER_AXIS_RIGHTY: 5,
+    }
+    _BUTTON_MAP = {
+        sdl2.SDL_CONTROLLER_BUTTON_A: 1,
+        sdl2.SDL_CONTROLLER_BUTTON_B: 2,
+        sdl2.SDL_CONTROLLER_BUTTON_X: 3,
+        sdl2.SDL_CONTROLLER_BUTTON_Y: 4,
+        sdl2.SDL_CONTROLLER_BUTTON_LEFTSHOULDER: 5,
+        sdl2.SDL_CONTROLLER_BUTTON_RIGHTSHOULDER: 6,
+        sdl2.SDL_CONTROLLER_BUTTON_BACK: 7,
+        sdl2.SDL_CONTROLLER_BUTTON_START: 8,
+        sdl2.SDL_CONTROLLER_BUTTON_LEFTSTICK: 9,
+        sdl2.SDL_CONTROLLER_BUTTON_RIGHTSTICK: 10,
+    }
+    _DPAD = [
+        sdl2.SDL_CONTROLLER_BUTTON_DPAD_UP,
+        sdl2.SDL_CONTROLLER_BUTTON_DPAD_DOWN,
+        sdl2.SDL_CONTROLLER_BUTTON_DPAD_LEFT,
+        sdl2.SDL_CONTROLLER_BUTTON_DPAD_RIGHT,
+    ]
+
+    def _dpad_to_pov(up, down, left, right):
+        if up and right:
+            return 45
+        if right and down:
+            return 135
+        if down and left:
+            return 225
+        if left and up:
+            return 315
+        if up:
+            return 0
+        if right:
+            return 90
+        if down:
+            return 180
+        if left:
+            return 270
+        return -1
+
+    def _bridge_thread():
+        sdl2.SDL_SetHint(sdl2.SDL_HINT_JOYSTICK_MFI, b"1")
+        sdl2.SDL_Init(sdl2.SDL_INIT_GAMECONTROLLER)
+
+        # Allow time for controller discovery
+        for _ in range(20):
+            sdl2.SDL_PumpEvents()
+            time.sleep(0.05)
+
+        # Find the first game-controller-capable device
+        gc = None
+        for idx in range(sdl2.SDL_NumJoysticks()):
+            if sdl2.SDL_IsGameController(idx):
+                gc = sdl2.SDL_GameControllerOpen(idx)
+                break
+
+        if not gc:
+            logger.info("SDL2 bridge: no game controllers found")
+            sdl2.SDL_Quit()
+            return
+
+        gc_name = sdl2.SDL_GameControllerName(gc)
+        if gc_name and isinstance(gc_name, bytes):
+            gc_name = gc_name.decode()
+        logger.warning("SDL2 bridge: '%s' → HAL joystick port %d", gc_name, port)
+
+        sim = wpilib.simulation.GenericHIDSim(port)
+        sim.setAxisCount(6)
+        sim.setButtonCount(10)
+        sim.setPOVCount(1)
+
+        while True:
+            sdl2.SDL_PumpEvents()
+
+            for sdl_axis, wpi_axis in _AXIS_MAP.items():
+                raw = sdl2.SDL_GameControllerGetAxis(gc, sdl_axis)
+                sim.setRawAxis(wpi_axis, raw / 32767.0)
+
+            for sdl_btn, wpi_btn in _BUTTON_MAP.items():
+                sim.setRawButton(
+                    wpi_btn,
+                    bool(sdl2.SDL_GameControllerGetButton(gc, sdl_btn)),
+                )
+
+            dpad = [
+                bool(sdl2.SDL_GameControllerGetButton(gc, b)) for b in _DPAD
+            ]
+            sim.setPOV(0, _dpad_to_pov(*dpad))
+
+            time.sleep(0.01)
+
+    t = threading.Thread(
+        target=_bridge_thread, daemon=True, name="sdl2-controller-bridge"
+    )
+    t.start()
 
 
 class PhysicsEngine:
@@ -108,6 +247,38 @@ class PhysicsEngine:
             # ignore errors here and leave _navx_yaw as None.
             pass
 
+        # macOS controller bridge state — checked each tick until resolved.
+        # We monitor joystick ports 0 and 1 (driver and operator).  Once a
+        # port is assigned in the sim GUI but reports 0 axes we know GLFW
+        # cannot read it and start the SDL2 bridge for that port.
+        if sys.platform == "darwin":
+            self._controller_bridge_ports_to_check: set[int] = {0, 1}
+        else:
+            self._controller_bridge_ports_to_check: set[int] = set()
+
+    def _check_controller_bridge(self) -> None:
+        """On macOS, detect joystick ports that are mapped but broken (0 axes)
+        and start the SDL2 bridge for them.  Removes ports from the check set
+        once resolved (either working or bridged)."""
+        resolved = set()
+        for port in self._controller_bridge_ports_to_check:
+            axis_count, button_count, _ = hal.simulation.getJoystickCounts(port)
+            if axis_count > 0:
+                # GLFW is reading this port fine — no bridge needed
+                resolved.add(port)
+            elif button_count > 0:
+                # Controller is mapped (has buttons) but reports 0 axes —
+                # this is the broken GLFW state on macOS.
+                logger.warning(
+                    "macOS GLFW reports 0 axes for joystick port %d "
+                    "(buttons=%d) — starting SDL2 bridge",
+                    port, button_count,
+                )
+                _start_sdl2_controller_bridge(port)
+                resolved.add(port)
+            # else: nothing mapped yet, keep checking
+        self._controller_bridge_ports_to_check -= resolved
+
     def update_sim(self, now: float, tm_diff: float) -> None:
         """
         Called every simulation tick.
@@ -124,6 +295,10 @@ class PhysicsEngine:
             now: current timestamp in seconds
             tm_diff: elapsed time since last call in seconds
         """
+        # Check for broken macOS controller input each tick until resolved.
+        if self._controller_bridge_ports_to_check:
+            self._check_controller_bridge()
+
         module_states = []
 
         for module, drive_sim, steer_sim in zip(

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,3 +35,6 @@ robotpy-urcl
 #NFC battery tracking
 pyserial
 
+#macOS sim controller support (GLFW cannot read Xbox/PS controllers on macOS)
+pysdl2; sys_platform == "darwin"
+pysdl2-dll; sys_platform == "darwin"

--- a/subsystem/drivetrain/swerve_module.py
+++ b/subsystem/drivetrain/swerve_module.py
@@ -320,7 +320,12 @@ class SwerveModuleMk4iSparkMaxNeoCanCoder(Subsystem):
         self.drive_motor_encoder.setPosition(0)
         current_absolute_rotation = self.absolute_encoder.get_absolute_position(refresh=True)
         if not current_absolute_rotation.status.is_ok():
-            raise RuntimeError("Failed to retrieve starting absolute encoder position baselining relative encoders")
+            wpilib.reportWarning(
+                f"CANcoder {self.id_lookup['absolute_encoder']}: absolute position unavailable "
+                f"({current_absolute_rotation.status}), defaulting steer baseline to 0°"
+            )
+            self.steer_motor_encoder.setPosition(0)
+            return
         self.steer_motor_encoder.setPosition((current_absolute_rotation.value_as_double * 360.0) % (360.0))
 
     def current_raw_absolute_encoder_value(self) -> float | None:

--- a/utils/sim/sdl2_controller_bridge.py
+++ b/utils/sim/sdl2_controller_bridge.py
@@ -1,0 +1,195 @@
+"""
+SDL2 controller bridge for macOS WPILib simulation.
+
+Problem
+-------
+The WPILib sim GUI uses GLFW for joystick input.  On macOS, Apple's Game
+Controller framework claims Xbox and PlayStation controllers at the OS level,
+preventing GLFW from reading their axes or buttons (it reports 0 for both).
+This makes physical controllers unusable in the simulator on Mac.
+
+Solution
+--------
+SDL2 has native support for macOS's Game Controller framework and can read
+these controllers correctly.  This module spawns a daemon thread that:
+
+1. Initializes SDL2 and discovers connected game controllers.
+2. Maps each controller to a WPILib joystick port (first → port 0, second → port 1).
+3. Polls controller state at ~100 Hz and writes it to the HAL sim via
+   ``hal.simulation`` functions.
+
+The bridge writes directly to the HAL joystick data, bypassing the sim GUI's
+GLFW-based joystick handling entirely.
+
+Important
+---------
+**Do NOT assign the controller in the sim GUI's System Joystick panel.**
+If a controller is assigned there, the sim GUI will overwrite the HAL data
+with GLFW's empty values each tick, cancelling out the bridge's writes.
+
+If no physical controllers are detected, the bridge exits silently and the
+sim GUI's virtual joystick (keyboard-driven) panel continues to work normally.
+
+Requirements
+------------
+macOS only.  Install with::
+
+    pip install pysdl2 pysdl2-dll
+
+These are listed in ``requirements.txt`` with ``sys_platform == "darwin"``
+markers so they only install on Mac.
+
+Not needed on Windows or Linux where GLFW reads controllers correctly.
+"""
+
+import sys
+import threading
+import time
+
+import hal.simulation
+import wpilib
+
+
+def start_controller_bridge() -> None:
+    """Start the SDL2 controller bridge if running on macOS.
+
+    Safe to call on any platform — returns immediately on non-Mac systems.
+    Should be called once during ``PhysicsEngine.__init__``.
+    """
+    if sys.platform != "darwin":
+        return
+
+    try:
+        import sdl2
+    except ImportError:
+        wpilib.reportWarning(
+            "pysdl2 not installed — Xbox controller input in sim requires "
+            "'pip install pysdl2 pysdl2-dll' on macOS"
+        )
+        return
+
+    # --- Mapping tables: SDL2 game controller → WPILib XboxController ---
+
+    # SDL2 axis constant → WPILib axis index
+    axis_map = {
+        sdl2.SDL_CONTROLLER_AXIS_LEFTX: 0,        # kLeftX
+        sdl2.SDL_CONTROLLER_AXIS_LEFTY: 1,         # kLeftY
+        sdl2.SDL_CONTROLLER_AXIS_TRIGGERLEFT: 2,   # kLeftTrigger
+        sdl2.SDL_CONTROLLER_AXIS_TRIGGERRIGHT: 3,   # kRightTrigger
+        sdl2.SDL_CONTROLLER_AXIS_RIGHTX: 4,        # kRightX
+        sdl2.SDL_CONTROLLER_AXIS_RIGHTY: 5,        # kRightY
+    }
+
+    # SDL2 button constant → bit index in HAL button bitmask.
+    # WPILib buttons are 1-based: bit 0 = button 1 (A), bit 1 = button 2 (B), etc.
+    button_map = {
+        sdl2.SDL_CONTROLLER_BUTTON_A: 0,
+        sdl2.SDL_CONTROLLER_BUTTON_B: 1,
+        sdl2.SDL_CONTROLLER_BUTTON_X: 2,
+        sdl2.SDL_CONTROLLER_BUTTON_Y: 3,
+        sdl2.SDL_CONTROLLER_BUTTON_LEFTSHOULDER: 4,
+        sdl2.SDL_CONTROLLER_BUTTON_RIGHTSHOULDER: 5,
+        sdl2.SDL_CONTROLLER_BUTTON_BACK: 6,
+        sdl2.SDL_CONTROLLER_BUTTON_START: 7,
+        sdl2.SDL_CONTROLLER_BUTTON_LEFTSTICK: 8,
+        sdl2.SDL_CONTROLLER_BUTTON_RIGHTSTICK: 9,
+    }
+
+    # D-pad buttons for POV conversion (up, down, left, right order)
+    dpad_buttons = [
+        sdl2.SDL_CONTROLLER_BUTTON_DPAD_UP,
+        sdl2.SDL_CONTROLLER_BUTTON_DPAD_DOWN,
+        sdl2.SDL_CONTROLLER_BUTTON_DPAD_LEFT,
+        sdl2.SDL_CONTROLLER_BUTTON_DPAD_RIGHT,
+    ]
+
+    def _dpad_to_pov(up, down, left, right):
+        """Convert four d-pad booleans to a WPILib POV angle (-1 if released)."""
+        if up and right:
+            return 45
+        if right and down:
+            return 135
+        if down and left:
+            return 225
+        if left and up:
+            return 315
+        if up:
+            return 0
+        if right:
+            return 90
+        if down:
+            return 180
+        if left:
+            return 270
+        return -1
+
+    def _bridge_thread():
+        sdl2.SDL_SetHint(sdl2.SDL_HINT_JOYSTICK_MFI, b"1")
+        sdl2.SDL_Init(sdl2.SDL_INIT_GAMECONTROLLER)
+
+        # Allow time for controller discovery
+        for _ in range(20):
+            sdl2.SDL_PumpEvents()
+            time.sleep(0.05)
+
+        # Open all game-controller-capable devices.
+        # First controller → port 0 (driver), second → port 1 (operator).
+        controllers = []  # list of (sdl2_gc_handle, wpilib_port)
+        for idx in range(sdl2.SDL_NumJoysticks()):
+            if not sdl2.SDL_IsGameController(idx):
+                continue
+            gc = sdl2.SDL_GameControllerOpen(idx)
+            if not gc:
+                continue
+            port = len(controllers)
+            gc_name = sdl2.SDL_GameControllerName(gc)
+            if gc_name and isinstance(gc_name, bytes):
+                gc_name = gc_name.decode()
+            wpilib.reportWarning(
+                f"SDL2 bridge: '{gc_name}' → HAL joystick port {port}. "
+                f"Do NOT assign this controller in the sim GUI System Joystick panel."
+            )
+            hal.simulation.setJoystickAxisCount(port, 6)
+            hal.simulation.setJoystickButtonCount(port, 10)
+            hal.simulation.setJoystickPOVCount(port, 1)
+            hal.simulation.setJoystickIsXbox(port, True)
+            hal.simulation.setJoystickName(port, gc_name or "SDL2 Controller")
+            controllers.append((gc, port))
+
+        if not controllers:
+            # No physical controllers found — exit silently so the sim GUI's
+            # virtual joystick panel continues to work.
+            sdl2.SDL_Quit()
+            return
+
+        # Poll loop at ~100 Hz
+        while True:
+            sdl2.SDL_PumpEvents()
+
+            for gc, port in controllers:
+                # Axes (SDL2: -32768..32767 → WPILib: -1.0..1.0)
+                for sdl_axis, wpi_axis in axis_map.items():
+                    raw = sdl2.SDL_GameControllerGetAxis(gc, sdl_axis)
+                    hal.simulation.setJoystickAxis(port, wpi_axis, raw / 32767.0)
+
+                # Buttons → packed bitmask
+                buttons = 0
+                for sdl_btn, bit_index in button_map.items():
+                    if sdl2.SDL_GameControllerGetButton(gc, sdl_btn):
+                        buttons |= (1 << bit_index)
+                hal.simulation.setJoystickButtonsValue(port, buttons)
+
+                # D-pad → POV angle
+                dpad = [
+                    bool(sdl2.SDL_GameControllerGetButton(gc, b))
+                    for b in dpad_buttons
+                ]
+                hal.simulation.setJoystickPOV(port, 0, _dpad_to_pov(*dpad))
+
+            hal.simulation.notifyDriverStationNewData()
+            time.sleep(0.01)
+
+    t = threading.Thread(
+        target=_bridge_thread, daemon=True, name="sdl2-controller-bridge"
+    )
+    t.start()


### PR DESCRIPTION
## Summary
- **CANcoder init crash**: CTRE phoenix6 sim on Mac doesn't deliver CANcoder CAN frames during init. `baseline_relative_encoders()` now warns and defaults steer to 0° instead of crashing. Physics engine guards against empty module states.
- **Xbox controller input**: macOS Game Controller framework intercepts Xbox/PS controllers, making them invisible to GLFW (0 axes, 0 buttons). Added an SDL2-based bridge in `physics.py` that reads controllers via SDL2 and feeds input into the HAL sim. Requires `pysdl2`/`pysdl2-dll` (added to requirements.txt, macOS only). **Do not assign the controller in the sim GUI System Joystick panel** — the bridge handles it directly.
- **macOS CI**: Added a `macos-latest` test runner job that mirrors the existing Windows job.

## Test plan
- [x] Sim starts without crash on macOS (CANcoder fallback works)
- [x] SDL2 bridge detects Xbox controller and maps to HAL joystick port 0
- [x] Controller input verified via `examples/controller_test/`
- [ ] Verify Windows CI still passes (no changes to Windows code paths)
- [ ] Verify macOS CI job runs successfully
- [ ] Test with two controllers (driver + operator) if available

🤖 Generated with [Claude Code](https://claude.com/claude-code)